### PR TITLE
Use `redux-freeze` in dev to assert state immutability

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "jest": "^22.2.1",
     "mocha": "^5.0.0",
     "react-test-renderer": "^16.2.0",
+    "redux-freeze": "^0.1.5",
     "unexpected": "^10.36.3",
     "unexpected-react": "^5.0.1",
     "webpack-udev-server": "^0.8.0"

--- a/src/store/createStore.js
+++ b/src/store/createStore.js
@@ -42,6 +42,7 @@ function createStore<
     applyMiddleware(
       thunkMiddleware.withExtraArgument(context),
       routerMiddleware(history),
+      ...__DEV__ ? [require('redux-freeze').default] : [],
     ),
     identity,
   );


### PR DESCRIPTION
This will help catch accidental state mutation in dev builds. It is not enabled in prod builds for the sake of performance.